### PR TITLE
feat(wallet): Add balance calculation logic

### DIFF
--- a/server/src/transaction/transaction.d.ts
+++ b/server/src/transaction/transaction.d.ts
@@ -18,13 +18,13 @@ export type Output = {
 
 export type OutputParams = {
   senderWallet: Wallet;
-  receiverWallet: Wallet;
+  recipientAddress: string;
   amount: number;
 };
 
 export type TransactionParams = {
   senderWallet: Wallet;
-  receiverWallet: Wallet;
+  recipientAddress: string;
   amount: number;
   input?: Input;
   output?: Output;

--- a/server/src/transaction/transaction.d.ts
+++ b/server/src/transaction/transaction.d.ts
@@ -29,3 +29,9 @@ export type TransactionParams = {
   input?: Input;
   output?: Output;
 };
+
+export type UpdateParams = {
+  senderWallet: Wallet;
+  recipientAddress: string;
+  amount: number;
+}

--- a/server/src/transaction/transaction.ts
+++ b/server/src/transaction/transaction.ts
@@ -15,21 +15,21 @@ export default class Transaction {
 
   constructor({
     senderWallet,
-    receiverWallet,
+    recipientAddress,
     amount,
     input,
     output,
   }: TransactionParams) {
     this.id = uuid();
     this.output =
-      output || this.createOutput({ senderWallet, receiverWallet, amount });
+      output || this.createOutput({ senderWallet, recipientAddress, amount });
     this.input =
       input || this.createInput({ senderWallet, output: this.output });
   }
 
-  createOutput({ senderWallet, receiverWallet, amount }: OutputParams): Output {
+  createOutput({ senderWallet, recipientAddress, amount }: OutputParams): Output {
     return {
-      [receiverWallet.keypair.getPublicKey()]: amount,
+      [recipientAddress]: amount,
       [senderWallet.keypair.getPublicKey()]: senderWallet.balance - amount,
     };
   }

--- a/server/src/transaction/transaction.ts
+++ b/server/src/transaction/transaction.ts
@@ -5,6 +5,7 @@ import {
   Output,
   OutputParams,
   TransactionParams,
+  UpdateParams,
 } from './transaction.d.js';
 import KeyPair from '../wallet/keypair.js';
 
@@ -41,6 +42,23 @@ export default class Transaction {
       amount: senderWallet.balance,
       signature: senderWallet.keypair.sign(output),
     };
+  }
+
+  update({ senderWallet, recipientAddress, amount }: UpdateParams) {
+    if (amount > this.output[senderWallet.getPublicKey()]) {
+      console.error(`Amount ${amount} exceeds balance.`);
+      return;
+    }
+
+    if (!this.output[recipientAddress]) {
+      this.output[recipientAddress] = amount;
+    } else {
+      this.output[recipientAddress] += amount;
+    }
+
+    this.output[senderWallet.getPublicKey()] -= amount;
+
+    this.input = this.createInput({ senderWallet, output: this.output })
   }
 
   static isValidTransaction(transaction: Transaction): boolean {

--- a/server/src/wallet/keypair.ts
+++ b/server/src/wallet/keypair.ts
@@ -38,23 +38,23 @@ export default class KeyPair {
   static isValidHexKeyPair(keypair: HexKeyPair): boolean {
     const { publicKey, privateKey } = keypair;
     if (!publicKey || !privateKey) {
-      console.log('incoming keys must not be empty');
+      console.error('incoming keys must not be empty');
       return false;
     }
 
     const isHex = new RegExp(/^[0-9a-f]+$/);
     if (!isHex.test(publicKey) || !isHex.test(privateKey)) {
-      console.log('incoming keys must be a hex string');
+      console.error('incoming keys must be a hex string');
       return false;
     }
 
     if (publicKey.length !== 88 * 2) {
-      console.log('publicKey length is NOT isValid');
+      console.error('publicKey length is NOT isValid');
       return false;
     }
 
     if (privateKey.length !== 135 * 2) {
-      console.log('privateKey length is NOT isValid');
+      console.error('privateKey length is NOT isValid');
       return false;
     }
 
@@ -109,7 +109,7 @@ export default class KeyPair {
         });
       }
     } catch (error) {
-      console.log(`this ${type} key contains the wrong bytes`);
+      console.error(`this ${type} key contains the wrong bytes`);
       return false;
     }
 

--- a/server/src/wallet/wallet.d.ts
+++ b/server/src/wallet/wallet.d.ts
@@ -1,4 +1,12 @@
+import Block from '../blockchain/block.js';
+
 export type createTransactionParams = {
   recipientAddress: string;
   amount: number;
+  chain?: Block[];
+}
+
+export type calculateBalanceParams = {
+  chain: Block[];
+  address: string;
 }

--- a/server/src/wallet/wallet.d.ts
+++ b/server/src/wallet/wallet.d.ts
@@ -1,0 +1,4 @@
+export type createTransactionParams = {
+  recipientAddress: string;
+  amount: number;
+}

--- a/server/src/wallet/wallet.ts
+++ b/server/src/wallet/wallet.ts
@@ -1,6 +1,8 @@
 import { INITIAL_BALANCE } from '../config.js';
-import KeyPair from './keypair.js';
 import { HexKeyPair, SelfVerifyParams } from './keypair.d.js';
+import { createTransactionParams } from './wallet.d.js';
+import KeyPair from './keypair.js';
+import Transaction from '../transaction/transaction.js';
 
 export default class Wallet {
   keypair: KeyPair;
@@ -15,6 +17,18 @@ export default class Wallet {
     this.balance = INITIAL_BALANCE;
   }
 
+  createTransaction({
+    recipientAddress,
+    amount,
+  }: createTransactionParams): Transaction | undefined {
+    if (amount > this.balance) {
+      console.error('Amount exceeds balance');
+      return;
+    }
+
+    return new Transaction({ senderWallet: this, recipientAddress, amount });
+  }
+
   sign(data: any): string {
     return this.keypair.sign(data);
   }
@@ -23,7 +37,7 @@ export default class Wallet {
     return this.keypair.verify({ data, signature });
   }
 
-  import({ publicKey, privateKey}: HexKeyPair) {
+  import({ publicKey, privateKey }: HexKeyPair) {
     this.keypair.import({ publicKey, privateKey });
   }
 }

--- a/server/src/wallet/wallet.ts
+++ b/server/src/wallet/wallet.ts
@@ -1,5 +1,6 @@
 import { INITIAL_BALANCE } from '../config.js';
 import KeyPair from './keypair.js';
+import { HexKeyPair, SelfVerifyParams } from './keypair.d.js';
 
 export default class Wallet {
   keypair: KeyPair;
@@ -12,5 +13,17 @@ export default class Wallet {
     this.publicKey = this.keypair.getPublicKey();
     this.privateKey = this.keypair.getPrivateKey();
     this.balance = INITIAL_BALANCE;
+  }
+
+  sign(data: any): string {
+    return this.keypair.sign(data);
+  }
+
+  verify({ data, signature }: SelfVerifyParams): boolean {
+    return this.keypair.verify({ data, signature });
+  }
+
+  import({ publicKey, privateKey}: HexKeyPair) {
+    this.keypair.import({ publicKey, privateKey });
   }
 }

--- a/server/src/wallet/wallet.ts
+++ b/server/src/wallet/wallet.ts
@@ -40,4 +40,12 @@ export default class Wallet {
   import({ publicKey, privateKey }: HexKeyPair) {
     this.keypair.import({ publicKey, privateKey });
   }
+
+  getPublickey() {
+    return this.publicKey;
+  }
+
+  getPrivateKey() {
+    return this.publicKey;
+  }
 }

--- a/server/test/chain.test.ts
+++ b/server/test/chain.test.ts
@@ -77,16 +77,27 @@ describe('Blockchain', () => {
   });
 
   describe('replaceChain()', () => {
+    let consoleErrorSpy: jest.SpyInstance;
+    beforeEach(() => {
+      consoleErrorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(jest.fn());
+    });
     describe('the new chain is shorter to the current chain', () => {
       beforeEach(() => {
         blockchain.addBlock({ data: 'block1' });
         blockchain.addBlock({ data: 'block2' });
       });
 
+      afterEach(() => {
+        consoleErrorSpy.mockRestore();
+      });
+
       describe('and the chain is valid', () => {
         it('retains the current `chain` instance', () => {
           blockchain.replaceChain(newChain.chain);
           expect(blockchain.chain).not.toEqual(newChain.chain);
+          expect(consoleErrorSpy).toBeCalled();
         });
       });
     });
@@ -109,6 +120,7 @@ describe('Blockchain', () => {
           newChain.chain[1].data = 'EVIL DATA';
           blockchain.replaceChain(newChain.chain);
           expect(blockchain.chain).not.toEqual(newChain.chain);
+          expect(consoleErrorSpy).toBeCalled();
         });
       });
     });

--- a/server/test/keypair.test.ts
+++ b/server/test/keypair.test.ts
@@ -98,6 +98,7 @@ describe('KeyPair', () => {
   describe('import()', () => {
     let keypair: KeyPair = new KeyPair();
     let hexKeyPair: { publicKey: string; privateKey: string };
+    let consoleErrorSpy: jest.SpyInstance;
 
     beforeEach(() => {
       keypair = new KeyPair();
@@ -105,6 +106,15 @@ describe('KeyPair', () => {
         publicKey: kp.getPublicKey(),
         privateKey: kp.getPrivateKey(),
       };
+      consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(jest.fn());
+    });
+
+    afterEach(() => {
+      consoleErrorSpy.mockReset();
+    });
+
+    afterAll(() => {
+      consoleErrorSpy.mockRestore();
     });
 
     describe('the keypairs are valid hex keys', () => {
@@ -123,6 +133,7 @@ describe('KeyPair', () => {
             keypair.import(hexKeyPair);
             expect(keypair.publicKey.equals(kp.publicKey)).toBe(false);
             expect(keypair.privateKey.equals(kp.privateKey)).toBe(false);
+            expect(consoleErrorSpy).toBeCalled();
           });
         });
         describe('and `privateKey` is corrupted', () => {
@@ -138,6 +149,7 @@ describe('KeyPair', () => {
             keypair.import(hexKeyPair);
             expect(keypair.publicKey.equals(kp.publicKey)).toBe(false);
             expect(keypair.privateKey.equals(kp.privateKey)).toBe(false);
+            expect(consoleErrorSpy).toBeCalled();
           });
         });
       });
@@ -151,6 +163,7 @@ describe('KeyPair', () => {
           keypair.import(hexKeyPair);
           expect(keypair.publicKey.equals(kp.publicKey)).toBe(false);
           expect(keypair.privateKey.equals(kp.privateKey)).toBe(false);
+          expect(consoleErrorSpy).toBeCalled();
         });
       });
 
@@ -161,6 +174,7 @@ describe('KeyPair', () => {
           keypair.import(hexKeyPair);
           expect(keypair.publicKey.equals(kp.publicKey)).toBe(false);
           expect(keypair.privateKey.equals(kp.privateKey)).toBe(false);
+          expect(consoleErrorSpy).toBeCalled();
         });
       });
     });

--- a/server/test/wallet.test.ts
+++ b/server/test/wallet.test.ts
@@ -1,5 +1,6 @@
-import Wallet from '../src/wallet/wallet.js'
-import KeyPair from '../src/wallet/keypair.js'
+import Wallet from '../src/wallet/wallet.js';
+import KeyPair from '../src/wallet/keypair.js';
+import Transaction from '../src/transaction/transaction.js';
 import { INITIAL_BALANCE } from '../src/config.js';
 
 describe('Wallet', () => {
@@ -14,13 +15,48 @@ describe('Wallet', () => {
       expect(wallet.keypair instanceof KeyPair).toBe(true);
     });
     it('has a `publicKey` exported from `keypair`', () => {
-      expect(wallet.publicKey).toEqual(wallet.keypair.getPublicKey())
+      expect(wallet.publicKey).toEqual(wallet.keypair.getPublicKey());
     });
     it('has a `privateKey` exported from `keypair`', () => {
-      expect(wallet.privateKey).toEqual(wallet.keypair.getPrivateKey())
+      expect(wallet.privateKey).toEqual(wallet.keypair.getPrivateKey());
     });
     it('has a `balance` equal to `INITIAL_BALANCE`', () => {
       expect(wallet.balance).toEqual(INITIAL_BALANCE);
     });
-  })
-})
+  });
+
+  describe('createTransaction()', () => {
+    let recipientWallet: Wallet;
+    let transaction: Transaction | undefined;
+
+    beforeEach(() => {
+      recipientWallet = new Wallet();
+    });
+
+    describe('and amount is less/equal to balance', () => {
+      it('returns a valid transaction object', () => {
+        transaction = wallet.createTransaction({
+          recipientAddress: recipientWallet.publicKey,
+          amount: 2,
+        });
+        expect(transaction instanceof Transaction).toBe(true);
+        expect(Transaction.isValidTransaction(transaction!)).toBe(true);
+      });
+    });
+
+    describe('and amount is greater than balance', () => {
+      it('outputs an error', () => {
+        const consoleErrorSpy = jest
+          .spyOn(console, 'error')
+          .mockImplementation(jest.fn());
+        transaction = wallet.createTransaction({
+          recipientAddress: recipientWallet.publicKey,
+          amount: 100,
+        });
+        expect(transaction).toBe(undefined);
+        expect(consoleErrorSpy).toBeCalled();
+        consoleErrorSpy.mockRestore();
+      });
+    });
+  });
+});

--- a/server/test/wallet.test.ts
+++ b/server/test/wallet.test.ts
@@ -6,9 +6,11 @@ import { INITIAL_BALANCE } from '../src/config.js';
 
 describe('Wallet', () => {
   let wallet: Wallet;
+  let blockchain: Blockchain;
 
   beforeEach(() => {
     wallet = new Wallet();
+    blockchain = new Blockchain();
   });
 
   describe('check properties', () => {
@@ -59,14 +61,29 @@ describe('Wallet', () => {
         consoleErrorSpy.mockRestore();
       });
     });
+
+    describe('and the `chain` is supplied as a parameter', () => {
+      let calculateBalanceSpy: jest.SpyInstance;
+
+      beforeEach(() => {
+        calculateBalanceSpy = jest
+          .spyOn(Wallet, 'calculateBalance')
+          .mockImplementation(jest.fn());
+      });
+
+      it('calls calculateBalance() method', () => {
+        wallet.createTransaction({
+          recipientAddress: wallet.getPublicKey(),
+          amount: 1,
+          chain: blockchain.chain,
+        });
+        expect(calculateBalanceSpy).toBeCalled();
+        calculateBalanceSpy.mockRestore();
+      });
+    });
   });
 
   describe('calculateBalance()', () => {
-    let blockchain: Blockchain;
-
-    beforeEach(() => {
-      blockchain = new Blockchain();
-    });
 
     describe('`Wallet` does NOT have outputs in the blockchain', () => {
       it('returns the `INITIAL_BALANCE`', () => {

--- a/server/test/wallet.test.ts
+++ b/server/test/wallet.test.ts
@@ -1,6 +1,7 @@
 import Wallet from '../src/wallet/wallet.js';
 import KeyPair from '../src/wallet/keypair.js';
 import Transaction from '../src/transaction/transaction.js';
+import Blockchain from '../src/blockchain/chain.js';
 import { INITIAL_BALANCE } from '../src/config.js';
 
 describe('Wallet', () => {
@@ -56,6 +57,78 @@ describe('Wallet', () => {
         expect(transaction).toBe(undefined);
         expect(consoleErrorSpy).toBeCalled();
         consoleErrorSpy.mockRestore();
+      });
+    });
+  });
+
+  describe('calculateBalance()', () => {
+    let blockchain: Blockchain;
+
+    beforeEach(() => {
+      blockchain = new Blockchain();
+    });
+
+    describe('`Wallet` does NOT have outputs in the blockchain', () => {
+      it('returns the `INITIAL_BALANCE`', () => {
+        const balance = Wallet.calculateBalance({
+          chain: blockchain.chain,
+          address: wallet.getPublicKey(),
+        });
+        expect(balance).toEqual(INITIAL_BALANCE);
+      });
+    });
+
+    describe('`Wallet` IS receiving funds from the blockchain', () => {
+      let transaction1: Transaction | undefined;
+      let transaction2: Transaction | undefined;
+
+      beforeEach(() => {
+        transaction1 = new Wallet().createTransaction({
+          recipientAddress: wallet.publicKey,
+          amount: 2,
+        });
+        transaction2 = new Wallet().createTransaction({
+          recipientAddress: wallet.publicKey,
+          amount: 3,
+        });
+        blockchain.addBlock({ data: [transaction1, transaction2] });
+      });
+
+      it('adds the sum from `INITIAL_BALANCE` + t1 + t2 ...', () => {
+        const balance = Wallet.calculateBalance({
+          chain: blockchain.chain,
+          address: wallet.publicKey,
+        });
+        expect(balance).toEqual(
+          INITIAL_BALANCE +
+            transaction1!.output[wallet.getPublicKey()] +
+            transaction2!.output[wallet.getPublicKey()]
+        );
+      });
+    });
+
+    describe('`Wallet` IS sending funds to the blockchain', () => {
+      let transaction: Transaction | undefined;
+
+      beforeEach(() => {
+        transaction = wallet.createTransaction({
+          recipientAddress: new Wallet().getPublicKey(),
+          amount: 2,
+        });
+        transaction!.update({
+          senderWallet: wallet,
+          recipientAddress: new Wallet().getPublicKey(),
+          amount: 3,
+        });
+        blockchain.addBlock({ data: [transaction] });
+      });
+
+      it('subtracts the sum from `INITIAL_BALANCE` - tx', () => {
+        const balance = Wallet.calculateBalance({
+          chain: blockchain.chain,
+          address: wallet.getPublicKey(),
+        });
+        expect(balance).toEqual(transaction!.output[wallet.getPublicKey()]);
       });
     });
   });


### PR DESCRIPTION
* allow wallets to create transactions in the blockchain.
* calculate balance when a wallet conducts transactions.
* use most recent block when TX input matches `this` wallet.
* TX are only updated, when coming from the same sender.