### PR TITLE
fix(api,tx-pool): Peers not consuming transaction messages

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -87,7 +87,7 @@ async function syncBlockchains() {
   }
   console.log(`sync chains event, fetching from root "${ROOT_NODE_ADDRESS}"`);
   const rootChain = (await response.json()) as Block[];
-  blockchain.replaceChain(rootChain);
+  blockchain.replaceChain({ chain: rootChain });
 }
 
 async function syncTransactionPool() {

--- a/server/src/transaction/transaction-pool.ts
+++ b/server/src/transaction/transaction-pool.ts
@@ -13,7 +13,7 @@ export default class TransactionPool {
   }
 
   addTransaction(transaction: Transaction) {
-    if (transaction instanceof Transaction) {
+    if (Transaction.isValidTransaction(transaction)) {
       this.transactionMap[transaction.id] = transaction;
     }
   }

--- a/server/test/chain.test.ts
+++ b/server/test/chain.test.ts
@@ -112,7 +112,6 @@ describe('Blockchain', () => {
 
       describe('and the chain is valid', () => {
         it('replaces the `chain` instance with the new chain', () => {
-          console.log(newChain.chain);
           blockchain.replaceChain({
             chain: newChain.chain,
             skipValidation: true,


### PR DESCRIPTION
* fixed API not starting due to improper call to `replaceChain()` 
* fixed peers in the network are not including tx messages to the pool.